### PR TITLE
fix up PR link error and use CTweakRef as much as possible

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -19,6 +19,9 @@
 
 #include "chainparamsseeds.h"
 
+uint64_t nMiningSvForkTime = 0;
+uint64_t nMiningForkTime = 1542300000;
+
 CBlock CreateGenesisBlock(CScript prefix,
     const std::string &comment,
     const CScript &genesisOutputScript,

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -170,8 +170,6 @@ set<CNetAddr> setservAddNodeAddresses;
 uint64_t maxGeneratedBlock = DEFAULT_BLOCK_MAX_SIZE;
 uint64_t excessiveBlockSize = DEFAULT_EXCESSIVE_BLOCK_SIZE;
 unsigned int excessiveAcceptDepth = DEFAULT_EXCESSIVE_ACCEPT_DEPTH;
-uint64_t nMiningSvForkTime = 0;
-uint64_t nMiningForkTime = 1542300000;
 unsigned int maxMessageSizeMultiplier = DEFAULT_MAX_MESSAGE_SIZE_MULTIPLIER;
 int nMaxOutConnections = DEFAULT_MAX_OUTBOUND_CONNECTIONS;
 

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -226,7 +226,7 @@ std::string ForkTimeValidator(const uint64_t &value, uint64_t *item, bool valida
 {
     if (validate)
     {
-        if (value != 0 && nMiningSvForkTime != 0)
+        if (value != 0 && miningSvForkTime.Value() != 0)
         {
             std::ostringstream ret;
             ret << "Only one fork can be enabled at a time";
@@ -250,7 +250,7 @@ std::string ForkTimeValidatorSV(const uint64_t &value, uint64_t *item, bool vali
 {
     if (validate)
     {
-        if (value != 0 && nMiningForkTime != 0)
+        if (value != 0 && miningForkTime.Value() != 0)
         {
             std::ostringstream ret;
             ret << "Only one fork can be enabled at a time";
@@ -445,7 +445,7 @@ void settingsToUserAgentString()
     BUComments.clear();
 
     std::string flavor;
-    if (nMiningSvForkTime != 0)
+    if (miningSvForkTime.Value() != 0)
         BUComments.push_back("SV");
 
     std::stringstream ebss;
@@ -475,12 +475,12 @@ void UnlimitedSetup(void)
     LoadTweaks(); // The above options are deprecated so the same parameter defined as a tweak will override them
 
     // If the user configures it to 1, assume this means default
-    if (nMiningForkTime == 1)
-        nMiningForkTime = Params().GetConsensus().nov2018ActivationTime;
-    if (nMiningSvForkTime == 1)
-        nMiningSvForkTime = Params().GetConsensus().nov2018ActivationTime;
+    if (miningForkTime.Value() == 1)
+        miningForkTime = Params().GetConsensus().nov2018ActivationTime;
+    if (miningSvForkTime.Value() == 1)
+        miningSvForkTime = Params().GetConsensus().nov2018ActivationTime;
 
-    if (nMiningForkTime != 0 && nMiningSvForkTime != 0)
+    if (miningForkTime.Value() != 0 && miningSvForkTime.Value() != 0)
     {
         LOGA("Both the SV and ABC forks are enabled.  You must choose one.");
         printf("Both the SV and ABC forks are enabled.  You must choose one.\n");

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -292,6 +292,14 @@ extern std::list<CStatBase *> mallocedStats;
 extern CCriticalSection cs_blockvalidationthread;
 void InterruptBlockValidationThreads();
 
+
+// Fork configuration
+/** This specifies the MTP time of the next fork */
+extern CTweakRef<uint64_t> miningForkTime;
+/** This specifies the MTP time of the SV fork */
+extern CTweakRef<uint64_t> miningSvForkTime;
+
+
 // Mining-Candidate start
 /** Return a Merkle root given a Coinbase hash and Merkle proof */
 uint256 CalculateMerkleRoot(uint256 &coinbase_hash, const std::vector<uint256> &merkleProof);

--- a/src/validation/forks.cpp
+++ b/src/validation/forks.cpp
@@ -21,14 +21,14 @@ bool IsDAAEnabled(const Consensus::Params &consensusparams, const CBlockIndex *p
     return IsDAAEnabled(consensusparams, pindexTip->nHeight);
 }
 
-bool IsNov152018Scheduled() { return nMiningForkTime != 0; }
+bool IsNov152018Scheduled() { return miningForkTime.Value() != 0; }
 bool IsNov152018Enabled(const Consensus::Params &consensusparams, const CBlockIndex *pindexTip)
 {
     if (pindexTip == nullptr)
     {
         return false;
     }
-    return pindexTip->IsforkActiveOnNextBlock(nMiningForkTime);
+    return pindexTip->IsforkActiveOnNextBlock(miningForkTime.Value());
 }
 
 bool IsNov152018Next(const Consensus::Params &consensusparams, const CBlockIndex *pindexTip)
@@ -37,18 +37,18 @@ bool IsNov152018Next(const Consensus::Params &consensusparams, const CBlockIndex
     {
         return false;
     }
-    return pindexTip->forkAtNextBlock(nMiningForkTime);
+    return pindexTip->forkAtNextBlock(miningForkTime.Value());
 }
 
 
-bool IsSv2018Scheduled() { return nMiningSvForkTime != 0; }
+bool IsSv2018Scheduled() { return miningSvForkTime.Value() != 0; }
 bool IsSv2018Enabled(const Consensus::Params &consensusparams, const CBlockIndex *pindexTip)
 {
     if (pindexTip == nullptr)
     {
         return false;
     }
-    return pindexTip->IsforkActiveOnNextBlock(nMiningSvForkTime);
+    return pindexTip->IsforkActiveOnNextBlock(miningSvForkTime.Value());
 }
 
 bool IsSv2018Next(const Consensus::Params &consensusparams, const CBlockIndex *pindexTip)
@@ -57,5 +57,5 @@ bool IsSv2018Next(const Consensus::Params &consensusparams, const CBlockIndex *p
     {
         return false;
     }
-    return pindexTip->forkAtNextBlock(nMiningSvForkTime);
+    return pindexTip->forkAtNextBlock(miningSvForkTime.Value());
 }


### PR DESCRIPTION
we only want to use the integer during init time because its not thread safe (but that's ok during single threaded init).  So put back the use of the CTweakRef in all places except chainparams.